### PR TITLE
Easier to use update API

### DIFF
--- a/src/MatchesSnapshots.php
+++ b/src/MatchesSnapshots.php
@@ -19,7 +19,7 @@ trait MatchesSnapshots
             return $this->markTestIncomplete("Snapshot created for {$snapshot->id()}");
         }
 
-        if (getenv('update_snapshots') == 1) {
+        if (in_array('--update', $_SERVER['argv'], true)) {
             return $this->updateSnapshot($type, $snapshot, $actual);
         }
 

--- a/src/MatchesSnapshots.php
+++ b/src/MatchesSnapshots.php
@@ -31,7 +31,7 @@ trait MatchesSnapshots
         try {
             $this->doSnapShotAssertion($type, $snapshot, $actual);
         } catch (PHPUnit_Framework_ExpectationFailedException $exception) {
-            $snapshot->update($actual);
+            $snapshot->create($actual);
 
             $this->markTestIncomplete("Snapshot updated for {$snapshot->id()}");
         }


### PR DESCRIPTION
### Changed

- Changed updating of snapshots to use `-d --update` when running `phpunit`.

### Fixed

- Fixed usage of non-existant `$snapshot->update()` method

---

We  had our [own package](https://github.com/madewithlove/phpunit-snapshots) for this, but yours is more feature complete. This PR fixes the updating of snapshots and adds a better API to update