### PR TITLE
Removes php 7 only syntax to add support for php 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 7.0
   - 7.1
+  - 5.6
 
 env:
   matrix:

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.0",
+        "php": "^5.6.0 || ^7.0",
         "phpunit/phpunit": "^5.7|^6.0"
     },
     "autoload": {

--- a/src/Driver.php
+++ b/src/Driver.php
@@ -12,7 +12,7 @@ interface Driver
      *
      * @return string
      */
-    public function serialize($data): string;
+    public function serialize($data);
 
     /**
      * The extension that should be used to save the snapshot file, without
@@ -20,7 +20,7 @@ interface Driver
      *
      * @return string
      */
-    public function extension(): string;
+    public function extension();
 
     /**
      * Match an expectation with a snapshot's actual contents. Should throw an

--- a/src/Drivers/JsonDriver.php
+++ b/src/Drivers/JsonDriver.php
@@ -8,7 +8,7 @@ use Spatie\Snapshots\Exceptions\CantBeSerialized;
 
 class JsonDriver implements Driver
 {
-    public function serialize($data): string
+    public function serialize($data)
     {
         if (! is_string($data)) {
             throw new CantBeSerialized('Only strings can be serialized to json');
@@ -17,7 +17,7 @@ class JsonDriver implements Driver
         return json_encode(json_decode($data), JSON_PRETTY_PRINT).PHP_EOL;
     }
 
-    public function extension(): string
+    public function extension()
     {
         return 'json';
     }

--- a/src/Drivers/VarDriver.php
+++ b/src/Drivers/VarDriver.php
@@ -7,12 +7,12 @@ use Spatie\Snapshots\Driver;
 
 class VarDriver implements Driver
 {
-    public function serialize($data): string
+    public function serialize($data)
     {
         return '<?php return '.var_export($data, true).';'.PHP_EOL;
     }
 
-    public function extension(): string
+    public function extension()
     {
         return 'php';
     }

--- a/src/Drivers/XmlDriver.php
+++ b/src/Drivers/XmlDriver.php
@@ -9,7 +9,7 @@ use Spatie\Snapshots\Exceptions\CantBeSerialized;
 
 class XmlDriver implements Driver
 {
-    public function serialize($data): string
+    public function serialize($data)
     {
         if (! is_string($data)) {
             throw new CantBeSerialized('Only strings can be serialized to xml');
@@ -24,7 +24,7 @@ class XmlDriver implements Driver
         return $domDocument->saveXML();
     }
 
-    public function extension(): string
+    public function extension()
     {
         return 'xml';
     }

--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -7,32 +7,32 @@ class Filesystem
     /** @var string */
     private $basePath;
 
-    public function __construct(string $basePath)
+    public function __construct($basePath)
     {
         $this->basePath = $basePath;
     }
 
-    public static function inDirectory(string $path): self
+    public static function inDirectory($path)
     {
         return new self($path);
     }
 
-    public function path(string $filename): string
+    public function path($filename)
     {
         return $this->basePath.DIRECTORY_SEPARATOR.$filename;
     }
 
-    public function has(string $filename): bool
+    public function has($filename)
     {
         return file_exists($this->path($filename));
     }
 
-    public function read(string $filename): string
+    public function read($filename)
     {
         return file_get_contents($this->path($filename));
     }
 
-    public function put(string $filename, string $contents)
+    public function put($filename, $contents)
     {
         if (! file_exists($this->basePath)) {
             mkdir($this->basePath);

--- a/src/MatchesSnapshots.php
+++ b/src/MatchesSnapshots.php
@@ -23,7 +23,7 @@ trait MatchesSnapshots
 
     public function assertMatchesSnapshot($actual, Driver $driver = null)
     {
-        $this->doSnapshotAssertion($actual, $driver ?? new VarDriver());
+        $this->doSnapshotAssertion($actual, isset($driver) ? $driver : new VarDriver());
     }
 
     public function assertMatchesXmlSnapshot($actual)
@@ -42,7 +42,7 @@ trait MatchesSnapshots
      *
      * @return string
      */
-    protected function getSnapshotId(): string
+    protected function getSnapshotId()
     {
         return (new ReflectionClass($this))->getShortName().'__'.
             $this->getName().'__'.
@@ -56,7 +56,7 @@ trait MatchesSnapshots
      *
      * @return string
      */
-    protected function getSnapshotDirectory(): string
+    protected function getSnapshotDirectory()
     {
         return dirname((new ReflectionClass($this))->getFileName()).
             DIRECTORY_SEPARATOR.
@@ -72,7 +72,7 @@ trait MatchesSnapshots
      *
      * @return bool
      */
-    protected function shouldUpdateSnapshots(): bool
+    protected function shouldUpdateSnapshots()
     {
         return in_array('--update-snapshots', $_SERVER['argv'], true);
     }

--- a/src/Snapshot.php
+++ b/src/Snapshot.php
@@ -14,7 +14,7 @@ class Snapshot
     private $driver;
 
     public function __construct(
-        string $id,
+        $id,
         Filesystem $filesystem,
         Driver $driver
     ) {
@@ -24,26 +24,26 @@ class Snapshot
     }
 
     public static function forTestCase(
-        string $id,
-        string $directory,
+        $id,
+        $directory,
         Driver $driver
-    ): self {
+    ) {
         $filesystem = Filesystem::inDirectory($directory);
 
         return new self($id, $filesystem, $driver);
     }
 
-    public function id(): string
+    public function id()
     {
         return $this->id;
     }
 
-    public function filename(): string
+    public function filename()
     {
         return $this->id.'.'.$this->driver->extension();
     }
 
-    public function exists(): bool
+    public function exists()
     {
         return $this->filesystem->has($this->filename());
     }

--- a/tests/Integration/ComparesSnapshotFiles.php
+++ b/tests/Integration/ComparesSnapshotFiles.php
@@ -26,7 +26,7 @@ trait ComparesSnapshotFiles
         $this->assertFileEquals($example, $snapshot);
     }
 
-    protected function emptyDirectory(string $path)
+    protected function emptyDirectory($path)
     {
         if (! file_exists($path)) {
             return true;
@@ -44,7 +44,7 @@ trait ComparesSnapshotFiles
         }
     }
 
-    protected function copyDirectory(string $sourcePath, string $destinationPath)
+    protected function copyDirectory($sourcePath, $destinationPath)
     {
         if (! file_exists($destinationPath)) {
             mkdir($destinationPath);

--- a/tests/Integration/MatchesSnapshotTest.php
+++ b/tests/Integration/MatchesSnapshotTest.php
@@ -192,7 +192,7 @@ class MatchesSnapshotTest extends TestCase
     /**
      * @return \PHPUnit_Framework_MockObject_MockObject
      */
-    private function getMatchesSnapshotMock(): PHPUnit_Framework_MockObject_MockObject
+    private function getMatchesSnapshotMock()
     {
         $mockMethods = [
             'markTestIncomplete',


### PR DESCRIPTION
* removes php 7 only syntax
* lowers php unit requirments
* lowers php version requirement
* adds php 5.6 tests to travis

I would have gone further back into 5.5 and 5.4, but the rabbit hole was getting a little deep.