### PR TITLE
Add custom error message support

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,9 +223,9 @@ class JsonDriver implements Driver
         return 'json';
     }
 
-    public function match($expected, $actual)
+    public function match($expected, $actual, string $message = '')
     {
-        Assert::assertJsonStringEqualsJsonString($actual, $expected);
+        Assert::assertJsonStringEqualsJsonString($expected, $actual, $message);
     }
 }
 ```

--- a/src/Driver.php
+++ b/src/Driver.php
@@ -29,8 +29,9 @@ interface Driver
      *
      * @param mixed $expected
      * @param mixed $actual
+     * @param string $message
      *
      * @throws \PHPUnit\Framework\ExpectationFailedException
      */
-    public function match($expected, $actual);
+    public function match($expected, $actual, string $message = '');
 }

--- a/src/Drivers/JsonDriver.php
+++ b/src/Drivers/JsonDriver.php
@@ -22,8 +22,8 @@ class JsonDriver implements Driver
         return 'json';
     }
 
-    public function match($expected, $actual)
+    public function match($expected, $actual, string $message = '')
     {
-        Assert::assertJsonStringEqualsJsonString($expected, $actual);
+        Assert::assertJsonStringEqualsJsonString($expected, $actual, $message);
     }
 }

--- a/src/Drivers/VarDriver.php
+++ b/src/Drivers/VarDriver.php
@@ -17,10 +17,10 @@ class VarDriver implements Driver
         return 'php';
     }
 
-    public function match($expected, $actual)
+    public function match($expected, $actual, string $message = '')
     {
         $evaluated = eval(substr($expected, strlen('<?php ')));
 
-        Assert::assertEquals($evaluated, $actual);
+        Assert::assertEquals($evaluated, $actual, $message);
     }
 }

--- a/src/Drivers/XmlDriver.php
+++ b/src/Drivers/XmlDriver.php
@@ -29,8 +29,8 @@ class XmlDriver implements Driver
         return 'xml';
     }
 
-    public function match($expected, $actual)
+    public function match($expected, $actual, string $message = '')
     {
-        Assert::assertXmlStringEqualsXmlString($expected, $actual);
+        Assert::assertXmlStringEqualsXmlString($expected, $actual, $message);
     }
 }

--- a/src/MatchesSnapshots.php
+++ b/src/MatchesSnapshots.php
@@ -21,17 +21,17 @@ trait MatchesSnapshots
         $this->snapshotIncrementor = 0;
     }
 
-    public function assertMatchesSnapshot($actual, Driver $driver = null)
+    public function assertMatchesSnapshot($actual, Driver $driver = null, string $message = '')
     {
-        $this->doSnapshotAssertion($actual, $driver ?? new VarDriver());
+        $this->doSnapshotAssertion($actual, $driver ?? new VarDriver(), $message);
     }
 
-    public function assertMatchesXmlSnapshot($actual)
+    public function assertMatchesXmlSnapshot($actual, string $message = '')
     {
         $this->assertMatchesSnapshot($actual, new XmlDriver());
     }
 
-    public function assertMatchesJsonSnapshot($actual)
+    public function assertMatchesJsonSnapshot($actual, string $message = '')
     {
         $this->assertMatchesSnapshot($actual, new JsonDriver());
     }
@@ -77,7 +77,7 @@ trait MatchesSnapshots
         return in_array('--update-snapshots', $_SERVER['argv'], true);
     }
 
-    protected function doSnapshotAssertion($actual, Driver $driver)
+    protected function doSnapshotAssertion($actual, Driver $driver, string $message = '')
     {
         $this->snapshotIncrementor++;
 
@@ -96,7 +96,7 @@ trait MatchesSnapshots
                 // We only want to update snapshots which need updating. If the snapshot doesn't
                 // match the expected output, we'll catch the failure, create a new snapshot and
                 // mark the test as incomplete.
-                $snapshot->assertMatches($actual);
+                $snapshot->assertMatches($actual, $message);
             } catch (ExpectationFailedException $exception) {
                 $this->updateSnapshotAndMarkTestIncomplete($snapshot, $actual);
             } catch (PHPUnit_Framework_ExpectationFailedException $exception) {
@@ -105,7 +105,7 @@ trait MatchesSnapshots
         }
 
         try {
-            $snapshot->assertMatches($actual);
+            $snapshot->assertMatches($actual, $message);
         } catch (ExpectationFailedException $exception) {
             $this->rethrowExpectationFailedExceptionWithUpdateSnapshotsPrompt($exception);
         } catch (PHPUnit_Framework_ExpectationFailedException $exception) {

--- a/src/MatchesSnapshots.php
+++ b/src/MatchesSnapshots.php
@@ -28,12 +28,12 @@ trait MatchesSnapshots
 
     public function assertMatchesXmlSnapshot($actual, string $message = '')
     {
-        $this->assertMatchesSnapshot($actual, new XmlDriver());
+        $this->assertMatchesSnapshot($actual, new XmlDriver(), $message);
     }
 
     public function assertMatchesJsonSnapshot($actual, string $message = '')
     {
-        $this->assertMatchesSnapshot($actual, new JsonDriver());
+        $this->assertMatchesSnapshot($actual, new JsonDriver(), $message);
     }
 
     /**

--- a/src/Snapshot.php
+++ b/src/Snapshot.php
@@ -48,9 +48,9 @@ class Snapshot
         return $this->filesystem->has($this->filename());
     }
 
-    public function assertMatches($actual)
+    public function assertMatches($actual, string $message = '')
     {
-        $this->driver->match($this->filesystem->read($this->filename()), $actual);
+        $this->driver->match($this->filesystem->read($this->filename()), $actual, $message);
     }
 
     public function create($actual)

--- a/tests/Integration/AssertionTest.php
+++ b/tests/Integration/AssertionTest.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Snapshots\Test\Integration;
 
+use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
 use Spatie\Snapshots\MatchesSnapshots;
 
@@ -46,5 +47,53 @@ class AssertionTest extends TestCase
     {
         $this->assertMatchesSnapshot('Foo');
         $this->assertMatchesSnapshot('Bar');
+    }
+
+    /** @test */
+    public function can_set_custom_string_error_message()
+    {
+        $customMessage = 'custom string error message';
+
+        try {
+            $this->assertMatchesSnapshot('Bar', null, $customMessage);
+        } catch (ExpectationFailedException $e) {
+            $this->assertNotSame(false, strpos($e->getMessage(), $customMessage), 'Failed to find custom string error message');
+            return;
+        }
+
+        /** Mark test as failed if we don't get a ExpectationFailedException */
+        throw new ExpectationFailedException('ExpectationFailedException did not occur');
+    }
+
+    /** @test */
+    public function can_set_custom_xml_error_message()
+    {
+        $customMessage = 'custom XML error message';
+
+        try {
+            $this->assertMatchesXmlSnapshot('<baz><bar>Foo</bar></baz>', $customMessage);
+        } catch (ExpectationFailedException $e) {
+            $this->assertNotSame(false, strpos($e->getMessage(), $customMessage), 'Failed to find custom XML error message');
+            return;
+        }
+
+        /** Mark test as failed if we don't get a ExpectationFailedException */
+        throw new ExpectationFailedException('ExpectationFailedException did not occur');
+    }
+
+    /** @test */
+    public function can_set_custom_json_error_message()
+    {
+        $customMessage = 'custom JSON error message';
+
+        try {
+            $this->assertMatchesJsonSnapshot('{"bar":"bar","foo":"foo"}', $customMessage);
+        } catch (ExpectationFailedException $e) {
+            $this->assertNotSame(false, strpos($e->getMessage(), $customMessage), 'Failed to find custom JSON error message');
+            return;
+        }
+
+        /** Mark test as failed if we don't get a ExpectationFailedException */
+        throw new ExpectationFailedException('ExpectationFailedException did not occur');
     }
 }

--- a/tests/Integration/AssertionTest.php
+++ b/tests/Integration/AssertionTest.php
@@ -4,6 +4,7 @@ namespace Spatie\Snapshots\Test\Integration;
 
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
+use PHPUnit_Framework_ExpectationFailedException;
 use Spatie\Snapshots\MatchesSnapshots;
 
 class AssertionTest extends TestCase
@@ -59,10 +60,13 @@ class AssertionTest extends TestCase
         } catch (ExpectationFailedException $e) {
             $this->assertNotSame(false, strpos($e->getMessage(), $customMessage), 'Failed to find custom string error message');
             return;
+        } catch (PHPUnit_Framework_ExpectationFailedException $e) {
+            $this->assertNotSame(false, strpos($e->getMessage(), $customMessage), 'Failed to find custom string error message');
+            return;
         }
 
-        /** Mark test as failed if we don't get a ExpectationFailedException */
-        throw new ExpectationFailedException('ExpectationFailedException did not occur');
+        /* Mark test as incomplete if we don't get a ExpectationFailedException */
+        $this->markTestIncomplete('Expected exception did not occur');
     }
 
     /** @test */
@@ -75,10 +79,13 @@ class AssertionTest extends TestCase
         } catch (ExpectationFailedException $e) {
             $this->assertNotSame(false, strpos($e->getMessage(), $customMessage), 'Failed to find custom XML error message');
             return;
+        } catch (PHPUnit_Framework_ExpectationFailedException $e) {
+            $this->assertNotSame(false, strpos($e->getMessage(), $customMessage), 'Failed to find custom XML error message');
+            return;
         }
 
-        /** Mark test as failed if we don't get a ExpectationFailedException */
-        throw new ExpectationFailedException('ExpectationFailedException did not occur');
+        /* Mark test as incomplete if we don't get a ExpectationFailedException */
+        $this->markTestIncomplete('Expected exception did not occur');
     }
 
     /** @test */
@@ -91,9 +98,12 @@ class AssertionTest extends TestCase
         } catch (ExpectationFailedException $e) {
             $this->assertNotSame(false, strpos($e->getMessage(), $customMessage), 'Failed to find custom JSON error message');
             return;
+        } catch (PHPUnit_Framework_ExpectationFailedException $e) {
+            $this->assertNotSame(false, strpos($e->getMessage(), $customMessage), 'Failed to find custom JSON error message');
+            return;
         }
 
-        /** Mark test as failed if we don't get a ExpectationFailedException */
-        throw new ExpectationFailedException('ExpectationFailedException did not occur');
+        /* Mark test as incomplete if we don't get a ExpectationFailedException */
+        $this->markTestIncomplete('Expected exception did not occur');
     }
 }

--- a/tests/Integration/AssertionTest.php
+++ b/tests/Integration/AssertionTest.php
@@ -59,9 +59,11 @@ class AssertionTest extends TestCase
             $this->assertMatchesSnapshot('Bar', null, $customMessage);
         } catch (ExpectationFailedException $e) {
             $this->assertNotSame(false, strpos($e->getMessage(), $customMessage), 'Failed to find custom string error message');
+
             return;
         } catch (PHPUnit_Framework_ExpectationFailedException $e) {
             $this->assertNotSame(false, strpos($e->getMessage(), $customMessage), 'Failed to find custom string error message');
+
             return;
         }
 
@@ -78,9 +80,11 @@ class AssertionTest extends TestCase
             $this->assertMatchesXmlSnapshot('<baz><bar>Foo</bar></baz>', $customMessage);
         } catch (ExpectationFailedException $e) {
             $this->assertNotSame(false, strpos($e->getMessage(), $customMessage), 'Failed to find custom XML error message');
+
             return;
         } catch (PHPUnit_Framework_ExpectationFailedException $e) {
             $this->assertNotSame(false, strpos($e->getMessage(), $customMessage), 'Failed to find custom XML error message');
+
             return;
         }
 
@@ -97,9 +101,11 @@ class AssertionTest extends TestCase
             $this->assertMatchesJsonSnapshot('{"bar":"bar","foo":"foo"}', $customMessage);
         } catch (ExpectationFailedException $e) {
             $this->assertNotSame(false, strpos($e->getMessage(), $customMessage), 'Failed to find custom JSON error message');
+
             return;
         } catch (PHPUnit_Framework_ExpectationFailedException $e) {
             $this->assertNotSame(false, strpos($e->getMessage(), $customMessage), 'Failed to find custom JSON error message');
+
             return;
         }
 

--- a/tests/Integration/stubs/__snapshots__/AssertionTest__can_set_custom_json_error_message__1.json
+++ b/tests/Integration/stubs/__snapshots__/AssertionTest__can_set_custom_json_error_message__1.json
@@ -1,0 +1,5 @@
+{
+    "foo": "foo",
+    "bar": "bar",
+    "baz": "baz"
+}

--- a/tests/Integration/stubs/__snapshots__/AssertionTest__can_set_custom_string_error_message__1.php
+++ b/tests/Integration/stubs/__snapshots__/AssertionTest__can_set_custom_string_error_message__1.php
@@ -1,0 +1,1 @@
+<?php return 'Foo';

--- a/tests/Integration/stubs/__snapshots__/AssertionTest__can_set_custom_xml_error_message__1.xml
+++ b/tests/Integration/stubs/__snapshots__/AssertionTest__can_set_custom_xml_error_message__1.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<foo>
+  <bar>Baz</bar>
+</foo>

--- a/tests/Unit/Drivers/JsonDriverTest.php
+++ b/tests/Unit/Drivers/JsonDriverTest.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Snapshots\Test\Unit\Drivers;
 
+use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
 use Spatie\Snapshots\Drivers\JsonDriver;
 use Spatie\Snapshots\Exceptions\CantBeSerialized;
@@ -31,5 +32,23 @@ class JsonDriverTest extends TestCase
         $this->expectException(CantBeSerialized::class);
 
         $driver->serialize(['foo' => 'bar']);
+    }
+
+    /** @test */
+    public function it_can_set_custom_error_message()
+    {
+        $driver = new JsonDriver();
+
+        $customMessage = 'custom JSON error message';
+
+        try {
+            $driver->match('{"foo":"foo"}', '{"bar":"bar"}', $customMessage);
+        } catch (ExpectationFailedException $e) {
+            $this->assertNotSame(false, strpos($e->getMessage(), $customMessage), 'Failed to find custom JSON error message');
+            return;
+        }
+
+        /** Mark test as failed if we don't get a ExpectationFailedException */
+        throw new ExpectationFailedException('ExpectationFailedException did not occur');
     }
 }

--- a/tests/Unit/Drivers/JsonDriverTest.php
+++ b/tests/Unit/Drivers/JsonDriverTest.php
@@ -4,6 +4,7 @@ namespace Spatie\Snapshots\Test\Unit\Drivers;
 
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
+use PHPUnit_Framework_ExpectationFailedException;
 use Spatie\Snapshots\Drivers\JsonDriver;
 use Spatie\Snapshots\Exceptions\CantBeSerialized;
 
@@ -46,9 +47,12 @@ class JsonDriverTest extends TestCase
         } catch (ExpectationFailedException $e) {
             $this->assertNotSame(false, strpos($e->getMessage(), $customMessage), 'Failed to find custom JSON error message');
             return;
+        } catch (PHPUnit_Framework_ExpectationFailedException $e) {
+            $this->assertNotSame(false, strpos($e->getMessage(), $customMessage), 'Failed to find custom JSON error message');
+            return;
         }
 
-        /** Mark test as failed if we don't get a ExpectationFailedException */
-        throw new ExpectationFailedException('ExpectationFailedException did not occur');
+        /* Mark test as incomplete if we don't get a ExpectationFailedException */
+        $this->markTestIncomplete('Expected exception did not occur');
     }
 }

--- a/tests/Unit/Drivers/JsonDriverTest.php
+++ b/tests/Unit/Drivers/JsonDriverTest.php
@@ -46,9 +46,11 @@ class JsonDriverTest extends TestCase
             $driver->match('{"foo":"foo"}', '{"bar":"bar"}', $customMessage);
         } catch (ExpectationFailedException $e) {
             $this->assertNotSame(false, strpos($e->getMessage(), $customMessage), 'Failed to find custom JSON error message');
+
             return;
         } catch (PHPUnit_Framework_ExpectationFailedException $e) {
             $this->assertNotSame(false, strpos($e->getMessage(), $customMessage), 'Failed to find custom JSON error message');
+
             return;
         }
 

--- a/tests/Unit/Drivers/VarDriverTest.php
+++ b/tests/Unit/Drivers/VarDriverTest.php
@@ -4,6 +4,7 @@ namespace Spatie\Snapshots\Test\Unit\Drivers;
 
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
+use PHPUnit_Framework_ExpectationFailedException;
 use Spatie\Snapshots\Drivers\VarDriver;
 
 class VarDriverTest extends TestCase
@@ -92,10 +93,13 @@ class VarDriverTest extends TestCase
         } catch (ExpectationFailedException $e) {
             $this->assertNotSame(false, strpos($e->getMessage(), $customMessage), 'Failed to find custom string error message');
             return;
+        } catch (PHPUnit_Framework_ExpectationFailedException $e) {
+            $this->assertNotSame(false, strpos($e->getMessage(), $customMessage), 'Failed to find custom string error message');
+            return;
         }
 
-        /** Mark test as failed if we don't get a ExpectationFailedException */
-        throw new ExpectationFailedException('ExpectationFailedException did not occur');
+        /* Mark test as incomplete if we don't get a ExpectationFailedException */
+        $this->markTestIncomplete('Expected exception did not occur');
     }
 }
 

--- a/tests/Unit/Drivers/VarDriverTest.php
+++ b/tests/Unit/Drivers/VarDriverTest.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Snapshots\Test\Unit\Drivers;
 
+use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
 use Spatie\Snapshots\Drivers\VarDriver;
 
@@ -77,6 +78,24 @@ class VarDriverTest extends TestCase
         ]);
 
         $this->assertEquals($expected, $driver->serialize(new Dummy()));
+    }
+
+    /** @test */
+    public function it_can_set_custom_error_message()
+    {
+        $driver = new VarDriver();
+
+        $customMessage = 'custom string error message';
+
+        try {
+            $driver->match('Foo', 'Bar', $customMessage);
+        } catch (ExpectationFailedException $e) {
+            $this->assertNotSame(false, strpos($e->getMessage(), $customMessage), 'Failed to find custom string error message');
+            return;
+        }
+
+        /** Mark test as failed if we don't get a ExpectationFailedException */
+        throw new ExpectationFailedException('ExpectationFailedException did not occur');
     }
 }
 

--- a/tests/Unit/Drivers/VarDriverTest.php
+++ b/tests/Unit/Drivers/VarDriverTest.php
@@ -92,9 +92,11 @@ class VarDriverTest extends TestCase
             $driver->match('Foo', 'Bar', $customMessage);
         } catch (ExpectationFailedException $e) {
             $this->assertNotSame(false, strpos($e->getMessage(), $customMessage), 'Failed to find custom string error message');
+
             return;
         } catch (PHPUnit_Framework_ExpectationFailedException $e) {
             $this->assertNotSame(false, strpos($e->getMessage(), $customMessage), 'Failed to find custom string error message');
+
             return;
         }
 

--- a/tests/Unit/Drivers/XmlDriverTest.php
+++ b/tests/Unit/Drivers/XmlDriverTest.php
@@ -47,9 +47,11 @@ class XmlDriverTest extends TestCase
             $driver->match('<foo><bar>baz</bar></foo>', '<baz><bar>foo</bar></baz>', $customMessage);
         } catch (ExpectationFailedException $e) {
             $this->assertNotSame(false, strpos($e->getMessage(), $customMessage), 'Failed to find custom XML error message');
+
             return;
         } catch (PHPUnit_Framework_ExpectationFailedException $e) {
             $this->assertNotSame(false, strpos($e->getMessage(), $customMessage), 'Failed to find custom XML error message');
+
             return;
         }
 

--- a/tests/Unit/Drivers/XmlDriverTest.php
+++ b/tests/Unit/Drivers/XmlDriverTest.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Snapshots\Test\Unit\Drivers;
 
+use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
 use Spatie\Snapshots\Drivers\XmlDriver;
 use Spatie\Snapshots\Exceptions\CantBeSerialized;
@@ -32,5 +33,23 @@ class XmlDriverTest extends TestCase
         $this->expectException(CantBeSerialized::class);
 
         $driver->serialize(['foo' => 'bar']);
+    }
+
+    /** @test */
+    public function it_can_set_custom_error_message()
+    {
+        $driver = new XmlDriver();
+
+        $customMessage = 'custom XML error message';
+
+        try {
+            $driver->match('<foo><bar>baz</bar></foo>', '<baz><bar>foo</bar></baz>', $customMessage);
+        } catch (ExpectationFailedException $e) {
+            $this->assertNotSame(false, strpos($e->getMessage(), $customMessage), 'Failed to find custom XML error message');
+            return;
+        }
+
+        /** Mark test as failed if we don't get a ExpectationFailedException */
+        throw new ExpectationFailedException('ExpectationFailedException did not occur');
     }
 }

--- a/tests/Unit/Drivers/XmlDriverTest.php
+++ b/tests/Unit/Drivers/XmlDriverTest.php
@@ -4,6 +4,7 @@ namespace Spatie\Snapshots\Test\Unit\Drivers;
 
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
+use PHPUnit_Framework_ExpectationFailedException;
 use Spatie\Snapshots\Drivers\XmlDriver;
 use Spatie\Snapshots\Exceptions\CantBeSerialized;
 
@@ -47,9 +48,12 @@ class XmlDriverTest extends TestCase
         } catch (ExpectationFailedException $e) {
             $this->assertNotSame(false, strpos($e->getMessage(), $customMessage), 'Failed to find custom XML error message');
             return;
+        } catch (PHPUnit_Framework_ExpectationFailedException $e) {
+            $this->assertNotSame(false, strpos($e->getMessage(), $customMessage), 'Failed to find custom XML error message');
+            return;
         }
 
-        /** Mark test as failed if we don't get a ExpectationFailedException */
-        throw new ExpectationFailedException('ExpectationFailedException did not occur');
+        /* Mark test as incomplete if we don't get a ExpectationFailedException */
+        $this->markTestIncomplete('Expected exception did not occur');
     }
 }


### PR DESCRIPTION
To clarify what it actually means when a snapshot fails, it would be useful to be able to provide a custom error message. This is especially so if you have multiple snapshots in a single test.