### PR TITLE
allow Laravel TestResponse in assertMatchesJsonSnapshot

### DIFF
--- a/src/MatchesSnapshots.php
+++ b/src/MatchesSnapshots.php
@@ -38,7 +38,7 @@ trait MatchesSnapshots
         if (class_exists($laravelTestResponseClass) && is_a($actual, $laravelTestResponseClass)) {
             $actual = $actual->getContent();
         }
-        
+
         $this->assertMatchesSnapshot($actual, new JsonDriver());
     }
 

--- a/src/MatchesSnapshots.php
+++ b/src/MatchesSnapshots.php
@@ -33,6 +33,12 @@ trait MatchesSnapshots
 
     public function assertMatchesJsonSnapshot($actual)
     {
+        $laravelTestResponseClass = '\Illuminate\Foundation\Testing\TestResponse';
+
+        if(class_exists($laravelTestResponseClass) && is_a($actual, $laravelTestResponseClass)) {
+            $actual = $actual->getContent();
+        }
+        
         $this->assertMatchesSnapshot($actual, new JsonDriver());
     }
 

--- a/src/MatchesSnapshots.php
+++ b/src/MatchesSnapshots.php
@@ -35,7 +35,7 @@ trait MatchesSnapshots
     {
         $laravelTestResponseClass = '\Illuminate\Foundation\Testing\TestResponse';
 
-        if(class_exists($laravelTestResponseClass) && is_a($actual, $laravelTestResponseClass)) {
+        if (class_exists($laravelTestResponseClass) && is_a($actual, $laravelTestResponseClass)) {
             $actual = $actual->getContent();
         }
         


### PR DESCRIPTION
I use the `assertMatchesJsonSnapshot` assertion to test my Laravel api, and i have to use it like this:
```php
$response = $this-get('/api/v1/');

$this->assertMatchesJsonSnapshot($response->getContent());
```

This PR allows me to simply do this:
```php
$response = $this-get('/api/v1/');

$this->assertMatchesJsonSnapshot($response);
```

I know this is not a Laravel specific package, but my guess is most people use this package in Laravel applications, so i thought it would be useful to add. Right now i override `assertMatchesJsonSnapshot` in my `BaseTestCase` to get the same functionality.

 I'm curious to see what you guys think about this change. 