### PR TITLE
Allow recursive mkdir

### DIFF
--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -66,7 +66,7 @@ class Filesystem
     public function put(string $filename, string $contents)
     {
         if (! file_exists($this->basePath)) {
-            mkdir($this->basePath);
+            mkdir($this->basePath, 0777, true);
         }
 
         file_put_contents($this->path($filename), $contents);


### PR DESCRIPTION
In larger projects, i split up my snapshots in subdirectories by overriding the `getSnapshotDirectory` and `getFileSnapshotDirectory` methods. 

I ran into the problem today that i tried creating a snapshot in a subdirectory, but the `__snapshots__` directory didn't exist yet, which caused `mkdir()` to fail.