### PR TITLE
[BUGFIX] sanitize filename

### DIFF
--- a/src/Snapshot.php
+++ b/src/Snapshot.php
@@ -43,9 +43,9 @@ class Snapshot
         $file = $this->id.'.'.$this->driver->extension();
         // Remove anything which isn't a word, whitespace, number
         // or any of the following caracters -_~,;[]().
-        $file = mb_ereg_replace("([^\w\s\d\-_~,;\[\]\(\).])", '', $file);
+        $file = preg_replace("([^\w\s\d\-_~,;\[\]\(\).])", '', $file);
         // Remove any runs of periods
-        $file = mb_ereg_replace("([\.]{2,})", '', $file);
+        $file = preg_replace("([\.]{2,})", '', $file);
         return $file;
     }
 

--- a/src/Snapshot.php
+++ b/src/Snapshot.php
@@ -40,7 +40,13 @@ class Snapshot
 
     public function filename(): string
     {
-        return $this->id.'.'.$this->driver->extension();
+        $file = $this->id.'.'.$this->driver->extension();
+        // Remove anything which isn't a word, whitespace, number
+        // or any of the following caracters -_~,;[]().
+        $file = mb_ereg_replace("([^\w\s\d\-_~,;\[\]\(\).])", '', $file);
+        // Remove any runs of periods
+        $file = mb_ereg_replace("([\.]{2,})", '', $file);
+        return $file;
     }
 
     public function exists(): bool

--- a/src/Snapshot.php
+++ b/src/Snapshot.php
@@ -46,6 +46,7 @@ class Snapshot
         $file = preg_replace("([^\w\s\d\-_~,;\[\]\(\).])", '', $file);
         // Remove any runs of periods
         $file = preg_replace("([\.]{2,})", '', $file);
+
         return $file;
     }
 

--- a/tests/Unit/SnapshotTest.php
+++ b/tests/Unit/SnapshotTest.php
@@ -43,4 +43,17 @@ class SnapshotTest extends TestCase
 
         $this->assertEquals('abc.php', $snapshot->filename());
     }
+
+    /** @test */
+    public function it_has_a_filename_which_is_valid_on_all_systems()
+    {
+        $this->driver
+            ->expects($this->once())
+            ->method('extension')
+            ->willReturn('php');
+
+        $snapshot = new Snapshot('ClassTest__testOne with data set "Empty"', $this->filesystem, $this->driver);
+
+        $this->assertEquals('ClassTest__testOne with data set Empty.php', $snapshot->filename());
+    }
 }


### PR DESCRIPTION
If The test uses Data Providers with titles. 
Then the Filename includes invalid Characters:
filename: ``ClassTest__testOne with data set "Empty"__1.php``

With this fix the file name will be sanitized and look like this:
``ClassTest__testOne with data set Empty__1.php``


Minimum reproducible TestClass:
````php
<?php

class ClassTest extends \PHPUnit\Framework\TestCase
{
    use \Spatie\Snapshots\MatchesSnapshots;

    /**
     * @dataProvider dataProvider
     * @param string $first
     */
    public function testOne(string $first)
    {
        $this->assertMatchesSnapshot(print_r($first, true));
    }

    public function dataProvider()
    {
        return [
            'Empty' => [''],
        ];
    }
}

````