### PR TITLE
Fix updating failed file-snapshots

### DIFF
--- a/src/MatchesSnapshots.php
+++ b/src/MatchesSnapshots.php
@@ -209,6 +209,8 @@ trait MatchesSnapshots
             $fileSystem->copy($filePath, $snapshotId);
 
             $this->registerSnapshotChange("File snapshot created for {$snapshotId}");
+
+            return;
         }
 
         if (! $fileSystem->fileEquals($filePath, $snapshotId)) {

--- a/src/MatchesSnapshots.php
+++ b/src/MatchesSnapshots.php
@@ -216,6 +216,8 @@ trait MatchesSnapshots
                 $fileSystem->copy($filePath, $snapshotId);
 
                 $this->registerSnapshotChange("File snapshot updated for {$snapshotId}");
+
+                return;
             }
 
             $fileSystem->copy($filePath, $failedSnapshotId);


### PR DESCRIPTION
https://github.com/spatie/phpunit-snapshot-assertions/pull/43 changed the way updating snapshots is handled. Now, if you update a failed file-snapshot, the test will fail. This happens because the old code threw an exception, but the new code doesn't. Adding a `return` fixes this.

Edit: added another `return` statement when a new file-snapshot is created