### PR TITLE
Update VarDriverTest for PHP 7.3

### DIFF
--- a/tests/Unit/Drivers/VarDriverTest.php
+++ b/tests/Unit/Drivers/VarDriverTest.php
@@ -61,6 +61,15 @@ class VarDriverTest extends TestCase
             '',
         ]);
 
+        if (version_compare(PHP_VERSION, '7.3.0') >= 0) {
+            $expected = implode(PHP_EOL, [
+                '<?php return (object) array(',
+                "   'foo' => 'bar',",
+                ');',
+                '',
+            ]);
+        }
+
         $this->assertEquals($expected, $driver->serialize((object) ['foo' => 'bar']));
     }
 


### PR DESCRIPTION
Update using version compare for greater than 7.3.0