### PR TITLE
Upgrade PHPUnit from 7 to 8 (php 7.2 required)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
         }
     ],
     "require": {
-        "php": "^7.1",
-        "phpunit/phpunit": "^7.0",
+        "php": "^7.2",
+        "phpunit/phpunit": "^8.0",
         "symfony/yaml": "^4.2"
     },
     "autoload": {

--- a/tests/Integration/AssertionTest.php
+++ b/tests/Integration/AssertionTest.php
@@ -10,7 +10,7 @@ class AssertionTest extends TestCase
     use ComparesSnapshotFiles;
     use MatchesSnapshots;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/MatchesSnapshotTest.php
+++ b/tests/Integration/MatchesSnapshotTest.php
@@ -3,8 +3,8 @@
 namespace Spatie\Snapshots\Test\Integration;
 
 use PHPUnit\Framework\ExpectationFailedException;
-use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 use Spatie\Snapshots\MatchesSnapshots;
 
 class MatchesSnapshotTest extends TestCase

--- a/tests/Integration/MatchesSnapshotTest.php
+++ b/tests/Integration/MatchesSnapshotTest.php
@@ -4,14 +4,14 @@ namespace Spatie\Snapshots\Test\Integration;
 
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
+use PHPUnit\Framework\MockObject\MockObject;
 use Spatie\Snapshots\MatchesSnapshots;
 
 class MatchesSnapshotTest extends TestCase
 {
     use ComparesSnapshotFiles;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -331,7 +331,7 @@ class MatchesSnapshotTest extends TestCase
         $this->assertFileNotExists($oldSnapshot);
     }
 
-    private function expectIncompleteMatchesSnapshotTest(PHPUnit_Framework_MockObject_MockObject $matchesSnapshotMock, callable $assertions)
+    private function expectIncompleteMatchesSnapshotTest(MockObject $matchesSnapshotMock, callable $assertions)
     {
         $matchesSnapshotMock
             ->expects($this->once())
@@ -342,7 +342,7 @@ class MatchesSnapshotTest extends TestCase
         $matchesSnapshotMock->markTestIncompleteIfSnapshotsHaveChanged();
     }
 
-    private function expectFail(PHPUnit_Framework_MockObject_MockObject $matchesSnapshotMock)
+    private function expectFail(MockObject $matchesSnapshotMock)
     {
         $matchesSnapshotMock
             ->expects($this->once())
@@ -355,9 +355,9 @@ class MatchesSnapshotTest extends TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject
+     * @return \PHPUnit\Framework\MockObject\MockObject
      */
-    private function getMatchesSnapshotMock(): PHPUnit_Framework_MockObject_MockObject
+    private function getMatchesSnapshotMock(): MockObject
     {
         $mockMethods = [
             'markTestIncomplete',

--- a/tests/Unit/SnapshotTest.php
+++ b/tests/Unit/SnapshotTest.php
@@ -15,7 +15,7 @@ class SnapshotTest extends TestCase
     /** @var \PHPUnit_Framework_MockObject_MockObject */
     private $driver;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
The proposal is the support of PhpUnit 8 and php 7.2 _(or newer)_ requirement. [Active support for PHP 7.1 ended on December 1, 2018](https://secure.php.net/supported-versions.php)

### Todo
- [x] update readme