### PR TITLE
Added test to check the JSON driver can take an array.

### DIFF
--- a/src/Drivers/JsonDriver.php
+++ b/src/Drivers/JsonDriver.php
@@ -29,7 +29,7 @@ class JsonDriver implements Driver
     public function match($expected, $actual)
     {
         if (is_array($actual)) {
-            $actual = json_encode($data, JSON_PRETTY_PRINT).PHP_EOL;
+            $actual = json_encode($actual, JSON_PRETTY_PRINT).PHP_EOL;
         }
 
         Assert::assertJsonStringEqualsJsonString($expected, $actual);

--- a/tests/Integration/AssertionTest.php
+++ b/tests/Integration/AssertionTest.php
@@ -42,6 +42,14 @@ class AssertionTest extends TestCase
     }
 
     /** @test */
+    public function can_match_an_array_snapshot()
+    {
+        $data = ['foo' => 'foo', 'bar' => 'bar', 'baz' => 'baz'];
+
+        $this->assertMatchesJsonSnapshot($data);
+    }
+
+    /** @test */
     public function can_match_a_file_hash_snapshot()
     {
         $filePath = __DIR__.'/stubs/example_snapshots/snapshot.json';


### PR DESCRIPTION
The recent update to allow arrays to be asserted against is using an undefined variable.

I have added a test to check that an array can be matched against and updated the variable.