### PR TITLE
Fix JsonDriver for v1

### DIFF
--- a/src/Drivers/JsonDriver.php
+++ b/src/Drivers/JsonDriver.php
@@ -29,7 +29,7 @@ class JsonDriver implements Driver
     public function match($expected, $actual)
     {
         if (is_array($actual)) {
-            $actual = json_encode($data, JSON_PRETTY_PRINT).PHP_EOL;
+            $actual = json_encode($actual, JSON_PRETTY_PRINT).PHP_EOL;
         }
 
         Assert::assertJsonStringEqualsJsonString($expected, $actual);

--- a/tests/Integration/AssertionTest.php
+++ b/tests/Integration/AssertionTest.php
@@ -42,6 +42,14 @@ class AssertionTest extends TestCase
     }
 
     /** @test */
+    public function can_match_an_array_snapshot()
+    {
+        $data = ['foo' => 'foo', 'bar' => 'bar', 'baz' => 'baz'];
+
+        $this->assertMatchesJsonSnapshot($data);
+    }
+
+    /** @test */
     public function can_match_a_file_hash_snapshot()
     {
         $filePath = __DIR__.'/stubs/example_snapshots/snapshot.json';


### PR DESCRIPTION
Cherry picks https://github.com/spatie/phpunit-snapshot-assertions/commit/9e77852202fc057bcd5b61d91ca897ac4301206b into v1 to fix the JsonDriver when taking an array $actual param.