### PR TITLE
Add support for PHPUnit 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": "^7.4",
         "ext-dom": "*",
-        "phpunit/phpunit": "^8.3",
+        "phpunit/phpunit": "^8.3|^9",
         "symfony/yaml": "^4.0|^5.0"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -23,7 +23,6 @@
         </whitelist>
     </filter>
     <logging>
-        <log type="tap" target="build/report.tap"/>
         <log type="junit" target="build/report.junit.xml"/>
         <log type="coverage-html" target="build/coverage"/>
         <log type="coverage-text" target="build/coverage.txt"/>


### PR DESCRIPTION
As PHPUnit 9 has been released, I was wondering if `phpunit-snapshot-assertions` would be easily portable and as it turns out, it is ;-)
Only point was: `tap` is not a supported log type anymore and PHPUnit will therefore not create that `build/report.tap` file anymore. I removed this from the `phpunit.xml.dist` file and hope this is ok.