### PR TITLE
Fix inconsistent line endings in JSON snapshots

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,3 +9,9 @@
 /.scrutinizer.yml   export-ignore
 /tests              export-ignore
 /example            export-ignore
+
+# All test snapshots and text stubs must have LF line endings
+tests/**/__snapshots__/**   text eol=lf
+tests/**/stubs/**           text eol=lf
+tests/**/stubs/**/*.jpg     binary
+tests/**/stubs/**/*.png     binary

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
         php: [7.4]
         dependency-version: [prefer-lowest, prefer-stable]
 

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         }
     },
     "scripts": {
-        "test": "vendor/bin/phpunit"
+        "test": "phpunit"
     },
     "config": {
         "sort-packages": true

--- a/src/Drivers/JsonDriver.php
+++ b/src/Drivers/JsonDriver.php
@@ -18,7 +18,7 @@ class JsonDriver implements Driver
             throw new CantBeSerialized('Resources can not be serialized to json');
         }
 
-        return json_encode($data, JSON_PRETTY_PRINT).PHP_EOL;
+        return json_encode($data, JSON_PRETTY_PRINT)."\n";
     }
 
     public function extension(): string
@@ -29,7 +29,7 @@ class JsonDriver implements Driver
     public function match($expected, $actual)
     {
         if (is_array($actual)) {
-            $actual = json_encode($actual, JSON_PRETTY_PRINT).PHP_EOL;
+            $actual = json_encode($actual, JSON_PRETTY_PRINT)."\n";
         }
 
         Assert::assertJsonStringEqualsJsonString($expected, $actual);

--- a/tests/Unit/Drivers/HtmlDriverTest.php
+++ b/tests/Unit/Drivers/HtmlDriverTest.php
@@ -13,7 +13,7 @@ class HtmlDriverTest extends TestCase
     {
         $driver = new HtmlDriver();
 
-        $expected = implode(PHP_EOL, [
+        $expected = implode("\n", [
             '<!DOCTYPE html>',
             '<html lang="en">',
             '<head></head>',

--- a/tests/Unit/Drivers/JsonDriverTest.php
+++ b/tests/Unit/Drivers/JsonDriverTest.php
@@ -116,7 +116,7 @@ class JsonDriverTest extends TestCase
 
         $this->expectException(CantBeSerialized::class);
 
-        $resource = fopen('.', 'r');
+        $resource = tmpfile();
 
         $driver->serialize($resource);
     }

--- a/tests/Unit/Drivers/JsonDriverTest.php
+++ b/tests/Unit/Drivers/JsonDriverTest.php
@@ -13,7 +13,7 @@ class JsonDriverTest extends TestCase
     {
         $driver = new JsonDriver();
 
-        $expected = implode(PHP_EOL, [
+        $expected = implode("\n", [
             '{',
             '    "foo": "bar"',
             '}',
@@ -28,7 +28,7 @@ class JsonDriverTest extends TestCase
     {
         $driver = new JsonDriver();
 
-        $expected = implode(PHP_EOL, [
+        $expected = implode("\n", [
             '{',
             '    "foo": "FOO",',
             '    "bar": "BAR",',
@@ -42,7 +42,7 @@ class JsonDriverTest extends TestCase
             'baz' => 'BAZ',
         ]));
 
-        $expected = implode(PHP_EOL, [
+        $expected = implode("\n", [
             '{',
             '    "foo": "FOO",',
             '    "bar": "BAR",',
@@ -74,7 +74,7 @@ class JsonDriverTest extends TestCase
     {
         $driver = new JsonDriver();
 
-        $expected = implode(PHP_EOL, [
+        $expected = implode("\n", [
             '[',
             '    "foo",',
             '    "bar",',
@@ -91,7 +91,7 @@ class JsonDriverTest extends TestCase
     {
         $driver = new JsonDriver();
 
-        $expected = implode(PHP_EOL, [
+        $expected = implode("\n", [
             '{',
             '    "foo": {',
             '        "bar": true',

--- a/tests/Unit/Drivers/ObjectDriverTest.php
+++ b/tests/Unit/Drivers/ObjectDriverTest.php
@@ -36,11 +36,11 @@ class ObjectDriverTest extends TestCase
     {
         $driver = new ObjectDriver();
 
-        $expected = <<<'YAML'
-foo:
-    bar: baz
-
-YAML;
+        $expected = implode("\n", [
+            'foo:',
+            '    bar: baz',
+            '',
+        ]);
 
         $this->assertEquals($expected, $driver->serialize(['foo' => ['bar' => 'baz']]));
     }
@@ -50,11 +50,11 @@ YAML;
     {
         $driver = new ObjectDriver();
 
-        $expected = <<<'YAML'
-- foo
-- bar
-
-YAML;
+        $expected = implode("\n", [
+            '- foo',
+            '- bar',
+            '',
+        ]);
 
         $this->assertEquals($expected, $driver->serialize(['foo', 'bar']));
     }
@@ -64,10 +64,10 @@ YAML;
     {
         $driver = new ObjectDriver();
 
-        $expected = <<<'YAML'
-foo: bar
-
-YAML;
+        $expected = implode("\n", [
+            'foo: bar',
+            '',
+        ]);
 
         $this->assertEquals($expected, $driver->serialize((object) ['foo' => 'bar']));
     }
@@ -77,13 +77,13 @@ YAML;
     {
         $driver = new ObjectDriver();
 
-        $expected = <<<'YAML'
-name: 'My name'
-valid: true
-dateTime: '2020-01-01T15:00:00+01:00'
-public: public
-
-YAML;
+        $expected = implode("\n", [
+            'name: \'My name\'',
+            'valid: true',
+            'dateTime: \'2020-01-01T15:00:00+01:00\'',
+            'public: public',
+            '',
+        ]);
 
         $this->assertEquals($expected, $driver->serialize(new Obj()));
     }

--- a/tests/Unit/Drivers/XmlDriverTest.php
+++ b/tests/Unit/Drivers/XmlDriverTest.php
@@ -13,7 +13,7 @@ class XmlDriverTest extends TestCase
     {
         $driver = new XmlDriver();
 
-        $expected = implode(PHP_EOL, [
+        $expected = implode("\n", [
             '<?xml version="1.0"?>',
             '<foo>',
             '  <bar>baz</bar>',

--- a/tests/Unit/Drivers/YamlDriverTest.php
+++ b/tests/Unit/Drivers/YamlDriverTest.php
@@ -12,7 +12,7 @@ class YamlDriverTest extends TestCase
     {
         $driver = new YamlDriver();
 
-        $yamlString = implode(PHP_EOL, [
+        $yamlString = implode("\n", [
             'foo: bar',
             'baz: qux',
             '',
@@ -26,7 +26,7 @@ class YamlDriverTest extends TestCase
     {
         $driver = new YamlDriver();
 
-        $expected = implode(PHP_EOL, [
+        $expected = implode("\n", [
             'foo: bar',
             'baz: qux',
             '',


### PR DESCRIPTION
The core of this PR is 66584f9 commit, everything else is to make tests run on Windows.

It fixes inconsistent EOLs in JSON snapshots on Windows by replacing OS-dependent `PHP_EOL` with `\n`.

`json_encode` with `JSON_PRETTY_PRINT` flag always use `\n` regardless of OS, but `PHP_EOL` yields `\r\n` on Windows causing inconsistent line ends and unnecessary diff for git, if files are regenerated.

All other commits are about making tests consistent between Linux and Windows by always using LF line ending. 

---

As a side note, it also revealed inconsistent behaviour between drivers. On Windows, most of the integration tests for JSON were passing regardless of line ending while other drivers failed, which is given by using `Assert::assertEquals` vs `Assert::assertJsonStringEqualsJsonString` in `match` methods (when the later serialise and deserialise the compared strings effectively eliminating line ending differences).

Also, from my experience, and regardless of this PR, using snapshots on Windows seems impossible without configuring git through `.gitatributes` to check out snapshot files with LF endings. Could be worth to add it as a note to the readme that users should add this line to their `.gitatributes` to make their snapshots OS-independent:

```
tests/**/__snapshots__/** text eol=lf
```