### PR TITLE
Moves default implementation of snapshot directory/id to concerns directory

### DIFF
--- a/src/Concerns/SnapshotDirectoryAware.php
+++ b/src/Concerns/SnapshotDirectoryAware.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Spatie\Snapshots\Concerns;
+
+use ReflectionClass;
+
+trait SnapshotDirectoryAware
+{
+    /*
+     * Determines the directory where snapshots are stored. By default a
+     * `__snapshots__` directory is created at the same level as the test
+     * class.
+     */
+    protected function getSnapshotDirectory(): string
+    {
+        return dirname((new ReflectionClass($this))->getFileName()).
+            DIRECTORY_SEPARATOR.
+            '__snapshots__';
+    }
+}

--- a/src/Concerns/SnapshotIdAware.php
+++ b/src/Concerns/SnapshotIdAware.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Spatie\Snapshots\Concerns;
+
+use ReflectionClass;
+
+trait SnapshotIdAware
+{
+    /*
+     * Determines the snapshot's id. By default, the test case's class and
+     * method names are used.
+     */
+    protected function getSnapshotId(): string
+    {
+        return (new ReflectionClass($this))->getShortName().'__'.
+            $this->getName().'__'.
+            $this->snapshotIncrementor;
+    }
+}

--- a/src/MatchesSnapshots.php
+++ b/src/MatchesSnapshots.php
@@ -3,8 +3,9 @@
 namespace Spatie\Snapshots;
 
 use PHPUnit\Framework\ExpectationFailedException;
-use ReflectionClass;
 use ReflectionObject;
+use Spatie\Snapshots\Concerns\SnapshotDirectoryAware;
+use Spatie\Snapshots\Concerns\SnapshotIdAware;
 use Spatie\Snapshots\Drivers\HtmlDriver;
 use Spatie\Snapshots\Drivers\JsonDriver;
 use Spatie\Snapshots\Drivers\ObjectDriver;
@@ -14,6 +15,8 @@ use Spatie\Snapshots\Drivers\YamlDriver;
 
 trait MatchesSnapshots
 {
+    use SnapshotDirectoryAware, SnapshotIdAware;
+
     protected int $snapshotIncrementor = 0;
 
     protected array $snapshotChanges = [];
@@ -103,29 +106,6 @@ trait MatchesSnapshots
     public function assertMatchesYamlSnapshot($actual): void
     {
         $this->assertMatchesSnapshot($actual, new YamlDriver());
-    }
-
-    /*
-     * Determines the snapshot's id. By default, the test case's class and
-     * method names are used.
-     */
-    protected function getSnapshotId(): string
-    {
-        return (new ReflectionClass($this))->getShortName().'__'.
-            $this->getName().'__'.
-            $this->snapshotIncrementor;
-    }
-
-    /*
-     * Determines the directory where snapshots are stored. By default a
-     * `__snapshots__` directory is created at the same level as the test
-     * class.
-     */
-    protected function getSnapshotDirectory(): string
-    {
-        return dirname((new ReflectionClass($this))->getFileName()).
-            DIRECTORY_SEPARATOR.
-            '__snapshots__';
     }
 
     /*


### PR DESCRIPTION
While developing [pest-plugin-snapshots](https://github.com/spatie/pest-plugin-snapshots) I need to override both `getSnapshotDirectory` and `getSnapshotId` without actually using inheritance.

This pull request moves both methods to specific traits, allowing pest-plugin-snapshots to override those two methods using composer autoload: https://github.com/spatie/pest-plugin-snapshots/pull/2.

Let me know if something is not clear.

Once you merge this pull request, please release a new **v4.2.2** version. As this can be consider as a small refactor.