### PR TITLE
Allow to call assertions from Laravel TestResponse

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,9 @@
         "symfony/yaml": "^4.0|^5.0"
     },
     "require-dev": {
+        "illuminate/support": "^7.0",
+        "illuminate/testing": "^7.0",
+        "orchestra/testbench": "^5.0",
         "phpunit/phpunit": "^9.1.0"
     },
     "autoload": {

--- a/src/Laravel/SnapshotsServiceProvider.php
+++ b/src/Laravel/SnapshotsServiceProvider.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Spatie\Snapshots\Laravel;
+
+use Illuminate\Support\ServiceProvider;
+use Illuminate\Testing\TestResponse;
+use RuntimeException;
+use Spatie\Snapshots\MatchesSnapshots;
+
+class SnapshotsServiceProvider extends ServiceProvider
+{
+    public function register()
+    {
+        TestResponse::macro('assertMatchesHtmlSnapshot', function () {
+            $backtrace = collect(debug_backtrace());
+            $index = $backtrace->search(function (array $call): bool {
+                return ($call['class'] ?? null) === TestResponse::class
+                    && ($call['function'] ?? null) === '__call'
+                    && ($call['args'][0] ?? null) === 'assertMatchesHtmlSnapshot';
+            });
+            $test = $backtrace->get($index+1);
+
+            if(!isset(class_uses($test['object'])[MatchesSnapshots::class])) {
+                throw new RuntimeException(sprintf('%s does not use %s', $test['class'], MatchesSnapshots::class));
+            }
+
+            /** @var TestResponse $response */
+            $response = $this;
+            call_user_func([$test['object'], 'assertMatchesHtmlSnapshot'], $response->getContent());
+        });
+    }
+}

--- a/tests/Integration/TestResponseTest.php
+++ b/tests/Integration/TestResponseTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Spatie\Snapshots\Test\Integration;
+
+use Illuminate\Testing\TestResponse;
+use Orchestra\Testbench\TestCase;
+use Spatie\Snapshots\Laravel\SnapshotsServiceProvider;
+use Spatie\Snapshots\MatchesSnapshots;
+
+class TestResponseTest extends TestCase
+{
+    use MatchesSnapshots;
+
+    protected function getPackageProviders($app)
+    {
+        return [
+            SnapshotsServiceProvider::class,
+        ];
+    }
+
+    /** @test */
+    public function it_can_assert_matches_html_snapshot()
+    {
+        TestResponse::fromBaseResponse(response()->noContent())->assertMatchesHtmlSnapshot();
+    }
+}


### PR DESCRIPTION
This PR is based on this tweet:
https://twitter.com/devgummibeer/status/1272090519120855042

This is only a quick idea - nothing polished, macro will be switched to mixin and put into dedicated class.
The primary point to discuss is the `debug_backtrace()` logic to find the class to call the assertions on and the fact that the test class has to use the trait.
My reason for this is to don't duplicate the whole snapshot filepath and update logic into the macros.
I have no idea if this current logic is compatible with pest. 🤔 Will try to add a simple pest test.
