### PR TITLE
Add ability to configure JsonDriver and ObjectDriver

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,24 @@ class OrderTest
 }
 ```
 
+### Configuring Drivers
+`JsonDriver` and `ObjectDriver` can be configurable by accessing their `config` in setup method of your base test class:
+```php
+JsonDriver::$config['flags'] = JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES; // json_encode flags (https://www.php.net/manual/ru/function.json-encode.php)
+```
+
+```php
+// Symfony Serializer YamlEncoder context: https://symfony.com/doc/current/components/serializer.html#the-yamlencoder-context-options
+ObjectDriver::$config['context'] = [
+    'yaml_inline' => 4,
+    'yaml_indent' => 8,
+];
+
+// or even different encoder:
+ObjectDriver::$config['encoder'] = JsonEncoder::class;
+ObjectDriver::$config['format'] = 'json';
+```
+
 ### Writing Custom Drivers
 
 Drivers ensure that different types of data can be serialized and matched in their own way. A driver is a class that implements the `Spatie\Snapshots\Driver` interface, which requires three method implementations: `serialize`, `extension` and `match`.

--- a/src/Drivers/JsonDriver.php
+++ b/src/Drivers/JsonDriver.php
@@ -18,7 +18,7 @@ class JsonDriver implements Driver
             throw new CantBeSerialized('Resources can not be serialized to json');
         }
 
-        return json_encode($data, JSON_PRETTY_PRINT)."\n";
+        return json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE)."\n";
     }
 
     public function extension(): string
@@ -29,7 +29,7 @@ class JsonDriver implements Driver
     public function match($expected, $actual)
     {
         if (is_array($actual)) {
-            $actual = json_encode($actual, JSON_PRETTY_PRINT)."\n";
+            $actual = json_encode($actual, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE)."\n";
         }
 
         Assert::assertJsonStringEqualsJsonString($expected, $actual);

--- a/src/Drivers/JsonDriver.php
+++ b/src/Drivers/JsonDriver.php
@@ -2,12 +2,18 @@
 
 namespace Spatie\Snapshots\Drivers;
 
+use JetBrains\PhpStorm\ArrayShape;
 use PHPUnit\Framework\Assert;
 use Spatie\Snapshots\Driver;
 use Spatie\Snapshots\Exceptions\CantBeSerialized;
 
 class JsonDriver implements Driver
 {
+    #[ArrayShape(['flags' => 'int'])]
+    public static $config = [
+        'flags' => JSON_PRETTY_PRINT,
+    ];
+
     public function serialize($data): string
     {
         if (is_string($data)) {
@@ -18,7 +24,7 @@ class JsonDriver implements Driver
             throw new CantBeSerialized('Resources can not be serialized to json');
         }
 
-        return json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE)."\n";
+        return json_encode($data, self::$config['flags'])."\n";
     }
 
     public function extension(): string
@@ -29,7 +35,7 @@ class JsonDriver implements Driver
     public function match($expected, $actual)
     {
         if (is_array($actual)) {
-            $actual = json_encode($actual, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE)."\n";
+            $actual = json_encode($actual, self::$config['flags'])."\n";
         }
 
         Assert::assertJsonStringEqualsJsonString($expected, $actual);

--- a/src/Drivers/ObjectDriver.php
+++ b/src/Drivers/ObjectDriver.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Snapshots\Drivers;
 
+use JetBrains\PhpStorm\ArrayShape;
 use PHPUnit\Framework\Assert;
 use Spatie\Snapshots\Driver;
 use Symfony\Component\Serializer\Encoder\YamlEncoder;
@@ -12,6 +13,17 @@ use Symfony\Component\Yaml\Yaml;
 
 class ObjectDriver implements Driver
 {
+    #[ArrayShape(['encoder' => 'string', 'format' => 'string', 'context' => 'array'])]
+    public static $config = [
+        'encoder' => YamlEncoder::class,
+        'format' => YamlEncoder::FORMAT,
+        'context' => [
+            'yaml_inline' => 2,
+            'yaml_indent' => 4,
+            'yaml_flags' => Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK,
+        ],
+    ];
+
     public function serialize($data): string
     {
         $normalizers = [
@@ -20,7 +32,7 @@ class ObjectDriver implements Driver
         ];
 
         $encoders = [
-            new YamlEncoder(),
+            new (self::$config['encoder'])(),
         ];
 
         $serializer = new Serializer($normalizers, $encoders);
@@ -32,11 +44,7 @@ class ObjectDriver implements Driver
         }
 
         return $this->dedent(
-            $serializer->serialize($data, 'yaml', [
-                'yaml_inline' => 2,
-                'yaml_indent' => 4,
-                'yaml_flags' => Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK,
-            ])
+            $serializer->serialize($data, self::$config['format'], self::$config['context'])
         );
     }
 

--- a/src/Drivers/ObjectDriver.php
+++ b/src/Drivers/ObjectDriver.php
@@ -32,8 +32,10 @@ class ObjectDriver implements Driver
             new ObjectNormalizer(),
         ];
 
+        $encoder = self::$config['encoder'];
+
         $encoders = [
-            new (self::$config['encoder'])(),
+            new $encoder(),
         ];
 
         $serializer = new Serializer($normalizers, $encoders);

--- a/tests/Unit/Drivers/JsonDriverTest.php
+++ b/tests/Unit/Drivers/JsonDriverTest.php
@@ -15,12 +15,13 @@ class JsonDriverTest extends TestCase
 
         $expected = implode("\n", [
             '{',
-            '    "foo": "bar"',
+            '    "foo": "bar",',
+            '    "строка в юникоде": "тест"',
             '}',
             '',
         ]);
 
-        $this->assertEquals($expected, $driver->serialize('{"foo":"bar"}'));
+        $this->assertEquals($expected, $driver->serialize('{"foo":"bar", "строка в юникоде":"тест"}'));
     }
 
     /** @test */

--- a/tests/Unit/Drivers/JsonDriverTest.php
+++ b/tests/Unit/Drivers/JsonDriverTest.php
@@ -8,6 +8,17 @@ use Spatie\Snapshots\Exceptions\CantBeSerialized;
 
 class JsonDriverTest extends TestCase
 {
+    protected $defaultConfig;
+
+    protected function setUp(): void {
+        $this->defaultConfig = JsonDriver::$config;
+    }
+
+    protected function tearDown(): void
+    {
+        JsonDriver::$config = $this->defaultConfig;
+    }
+
     /** @test */
     public function it_can_serialize_a_json_string_to_pretty_json()
     {
@@ -15,13 +26,40 @@ class JsonDriverTest extends TestCase
 
         $expected = implode("\n", [
             '{',
-            '    "foo": "bar",',
-            '    "строка в юникоде": "тест"',
+            '    "foo": "bar"',
             '}',
             '',
         ]);
 
-        $this->assertEquals($expected, $driver->serialize('{"foo":"bar", "строка в юникоде":"тест"}'));
+        $this->assertEquals($expected, $driver->serialize('{"foo":"bar"}'));
+    }
+
+    /** @test */
+    public function it_can_be_configurable()
+    {
+        $driver = new JsonDriver();
+
+        $expected = implode("\n", [
+            '{',
+            '    "foo": "bar",',
+            '    "\u044e\u043d\u0438\u043a\u043e\u0434": "\u0442\u0435\u0441\u0442"',
+            '}',
+            '',
+        ]);
+
+        $this->assertEquals($expected, $driver->serialize('{"foo":"bar", "юникод":"тест"}'));
+
+        JsonDriver::$config['flags'] = JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE;
+
+        $expected = implode("\n", [
+            '{',
+            '    "foo": "bar",',
+            '    "юникод": "тест"',
+            '}',
+            '',
+        ]);
+
+        $this->assertEquals($expected, $driver->serialize('{"foo":"bar", "юникод":"тест"}'));
     }
 
     /** @test */

--- a/tests/Unit/Drivers/ObjectDriverTest.php
+++ b/tests/Unit/Drivers/ObjectDriverTest.php
@@ -3,10 +3,25 @@
 namespace Spatie\Snapshots\Test\Unit\Drivers;
 
 use PHPUnit\Framework\TestCase;
+use Spatie\Snapshots\Drivers\JsonDriver;
 use Spatie\Snapshots\Drivers\ObjectDriver;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Encoder\YamlEncoder;
+use Symfony\Component\Yaml\Yaml;
 
 class ObjectDriverTest extends TestCase
 {
+    protected $defaultConfig;
+
+    protected function setUp(): void {
+        $this->defaultConfig = ObjectDriver::$config;
+    }
+
+    protected function tearDown(): void
+    {
+        ObjectDriver::$config = $this->defaultConfig;
+    }
+
     /** @test */
     public function it_can_serialize_a_string()
     {
@@ -68,6 +83,39 @@ class ObjectDriverTest extends TestCase
             'foo: bar',
             '',
         ]);
+
+        $this->assertEquals($expected, $driver->serialize((object) ['foo' => 'bar']));
+    }
+
+    /** @test */
+    public function it_can_be_configurable()
+    {
+        $driver = new ObjectDriver();
+
+        $expected = implode("\n", [
+            'foo: bar',
+            '',
+        ]);
+
+        $this->assertEquals($expected, $driver->serialize((object) ['foo' => 'bar']));
+
+        $expected = implode("\n", [
+            '  foo: bar',
+            '',
+        ]);
+
+        ObjectDriver::$config['context']['yaml_indent'] = 2;
+
+        $this->assertEquals($expected, $driver->serialize((object) ['foo' => 'bar']));
+
+
+        ObjectDriver::$config = [
+            'encoder' => JsonEncoder::class,
+            'format' => JsonEncoder::FORMAT,
+            'context' => []
+        ];
+
+        $expected = '{"foo":"bar"}';
 
         $this->assertEquals($expected, $driver->serialize((object) ['foo' => 'bar']));
     }


### PR DESCRIPTION
This is very handy feature when comparing diffs between snapshots with unicode symbols