### PR TITLE
Normalize windows line endings on HTML tests

### DIFF
--- a/src/Drivers/HtmlDriver.php
+++ b/src/Drivers/HtmlDriver.php
@@ -21,7 +21,13 @@ class HtmlDriver implements Driver
 
         @$domDocument->loadHTML($data); // to ignore HTML5 errors
 
-        return $domDocument->saveHTML();
+        $htmlValue = $domDocument->saveHTML();
+        // Normalize line endings for cross-platform tests.
+        if (PHP_OS_FAMILY === 'Windows') {
+            $htmlValue = implode("\n", explode("\r\n", $htmlValue));
+        }
+
+        return $htmlValue;
     }
 
     public function extension(): string


### PR DESCRIPTION
Discovered an error similar to the one reported here: https://github.com/spatie/phpunit-snapshot-assertions/pull/97

Just seems to be failing tests due to Windows line endings being used.
Example failing tests result: https://github.com/mallardduck/blade-boxicons/runs/5114345425?check_suite_focus=true