### PR TITLE
revert match process in JsonDriver

### DIFF
--- a/src/Drivers/JsonDriver.php
+++ b/src/Drivers/JsonDriver.php
@@ -28,7 +28,10 @@ class JsonDriver implements Driver
 
     public function match($expected, $actual)
     {
-        $expected = json_decode($expected, true);
+        if(is_string($actual)){
+            $actual = json_decode($actual, true, 512, JSON_THROW_ON_ERROR);
+        }
+        $expected = json_decode($expected, true, 512, JSON_THROW_ON_ERROR);
         Assert::assertEquals($expected, $actual);
     }
 }

--- a/src/Drivers/JsonDriver.php
+++ b/src/Drivers/JsonDriver.php
@@ -28,10 +28,7 @@ class JsonDriver implements Driver
 
     public function match($expected, $actual)
     {
-        if (is_array($actual)) {
-            $actual = json_encode($actual, JSON_PRETTY_PRINT)."\n";
-        }
-
-        Assert::assertJsonStringEqualsJsonString($expected, $actual);
+        $expected = json_decode($expected, true);
+        Assert::assertEquals($expected, $actual);
     }
 }


### PR DESCRIPTION
I'm using Intellij Idea when using the assertEquals and providing two arrays it does automatically do a diff and we can get a diff view, I'm sure other ides do too, but for strings comparison diff view is not either shown or is really messy and useless for big json objects, so this fixes all that.

Also fixes one of the issues of the other PR : https://github.com/spatie/phpunit-snapshot-assertions/pull/135#issuecomment-1071372599 and is backward compatible too. (no breaking changes, can work on all encode options.)

Before : 
<img width="656" alt="Screen Shot 1400-12-26 at 23 57 40" src="https://user-images.githubusercontent.com/27680142/158889619-733f0eca-c251-49b2-b9bb-9fc34713a32d.png">


After : 
<img width="926" alt="Screen Shot 1400-12-26 at 23 55 31" src="https://user-images.githubusercontent.com/27680142/158889420-d99ec0ff-1f74-4b38-8303-72b0b906c30b.png">
