### PR TITLE
Use `LIBXML_HTML_NODEFDTD` to maintain output consistency

### DIFF
--- a/src/Drivers/HtmlDriver.php
+++ b/src/Drivers/HtmlDriver.php
@@ -19,7 +19,7 @@ class HtmlDriver implements Driver
         $domDocument->preserveWhiteSpace = false;
         $domDocument->formatOutput = true;
 
-        @$domDocument->loadHTML($data); // to ignore HTML5 errors
+        @$domDocument->loadHTML($data, LIBXML_HTML_NODEFDTD); // to ignore HTML5 errors
 
         $htmlValue = $domDocument->saveHTML();
         // Normalize line endings for cross-platform tests.

--- a/tests/Unit/Drivers/HtmlDriverTest.php
+++ b/tests/Unit/Drivers/HtmlDriverTest.php
@@ -24,6 +24,27 @@ class HtmlDriverTest extends TestCase
 
         $this->assertEquals($expected, $driver->serialize('<!doctype html><html lang="en"><head></head><body><h1>Hello, world!</h1></body></html>'));
     }
+    
+    /** @test */
+    public function test_for_issue_140()
+    {
+        $driver = new HtmlDriver();
+
+        $expected = implode("\n", [
+            '<!DOCTYPE html>',
+            '<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">',
+            '<head>',
+            '<!--[if !mso]><!-->',
+            '<meta http-equiv="X-UA-Compatible" content="IE=edge">',
+            '<!--<![endif]-->',
+            '</head>',
+            '<body><h1>Hello, world!</h1></body>',
+            '</html>',
+            '',
+        ]);
+
+        $this->assertEquals($expected, $driver->serialize($expected));
+    }
 
     /** @test */
     public function it_can_only_serialize_strings()


### PR DESCRIPTION
Fix for #140 