### PR TITLE
Add test to cover HTML without doctype

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "php": "^7.3|^7.4|^8.0",
         "ext-dom": "*",
         "ext-json": "*",
+        "ext-libxml": "*",
         "composer-runtime-api": "^2.0",
         "phpunit/phpunit": "^8.3|^9.0",
         "symfony/property-access": "^4.0|^5.0|^6.0",

--- a/tests/Unit/Drivers/HtmlDriverTest.php
+++ b/tests/Unit/Drivers/HtmlDriverTest.php
@@ -24,7 +24,7 @@ class HtmlDriverTest extends TestCase
 
         $this->assertEquals($expected, $driver->serialize('<!doctype html><html lang="en"><head></head><body><h1>Hello, world!</h1></body></html>'));
     }
-    
+
     /** @test */
     public function test_for_issue_140()
     {
@@ -44,6 +44,22 @@ class HtmlDriverTest extends TestCase
         ]);
 
         $this->assertEquals($expected, $driver->serialize($expected));
+    }
+
+    /** @test */
+    public function it_can_serialize_a_html_string_without_a_doctype()
+    {
+        $driver = new HtmlDriver();
+
+        $expected = implode("\n", [
+            '<html lang="en">',
+            '<head></head>',
+            '<body><h1>Hello, world!</h1></body>',
+            '</html>',
+            '',
+        ]);
+
+        $this->assertEquals($expected, $driver->serialize('<html lang="en"><head></head><body><h1>Hello, world!</h1></body></html>'));
     }
 
     /** @test */


### PR DESCRIPTION
This PR should help prevent any future regression and adds a test to cover previously untested behavior. This is a follow up to unexpected breaks in #141 that affects certain input. Additionally this adds the XML extension as an explicit requirement as it's now being used after 141 as well.