### PR TITLE
Add type safe json matching

### DIFF
--- a/src/Drivers/JsonDriver.php
+++ b/src/Drivers/JsonDriver.php
@@ -32,6 +32,6 @@ class JsonDriver implements Driver
             $actual = json_decode($actual, true, 512, JSON_THROW_ON_ERROR);
         }
         $expected = json_decode($expected, true, 512, JSON_THROW_ON_ERROR);
-        Assert::assertEquals($expected, $actual);
+        Assert::assertJsonStringEqualsJsonString(json_encode($expected), json_encode($actual));
     }
 }

--- a/tests/Unit/Drivers/JsonDriverTest.php
+++ b/tests/Unit/Drivers/JsonDriverTest.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Snapshots\Test\Unit\Drivers;
 
+use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
 use Spatie\Snapshots\Drivers\JsonDriver;
 use Spatie\Snapshots\Exceptions\CantBeSerialized;
@@ -119,5 +120,26 @@ class JsonDriverTest extends TestCase
         $resource = tmpfile();
 
         $driver->serialize($resource);
+    }
+
+    /**
+     * @test
+     * @testWith ["{}", "{}", true]
+     *           ["{}", "{\"data\":1}", false]
+     *           ["{\"data\":1}", "{\"data\":1}", true]
+     *           ["{\"data\":1}", "{\"data\":\"1\"}", false]
+     */
+    public function it_can_match_json_strings(string $expected, string $actual, bool $assertion)
+    {
+        $driver = new JsonDriver();
+
+        try {
+            $driver->match($expected, $actual);
+            $status = true;
+        } catch (ExpectationFailedException $th) {
+            $status = false;
+        }
+
+        $this->assertSame($assertion, $status);
     }
 }


### PR DESCRIPTION
At the moment there is no type-safe check in the JsonDriver. If the data type of a field that can be converted internally by PHP (e.g. numeric strings), the test does not fail as expected.