### PR TITLE
Add tests for Text Driver and Windows EOL fixes

### DIFF
--- a/src/Drivers/TextDriver.php
+++ b/src/Drivers/TextDriver.php
@@ -9,6 +9,11 @@ class TextDriver implements Driver
 {
     public function serialize($data): string
     {
+        // Normalize line endings for cross-platform tests.
+        if (PHP_OS_FAMILY === 'Windows') {
+            $data = implode("\n", explode("\r\n", $data));
+        }
+
         return $data;
     }
 

--- a/tests/Unit/Drivers/TextDriverTest.php
+++ b/tests/Unit/Drivers/TextDriverTest.php
@@ -33,12 +33,13 @@ EOF));
     {
         $driver = new TextDriver();
 
-        $expected = <<<EOF
+        $expected = implode("\n", [
+            '',
+            '  GET|HEAD       / ..................................................... index',
+            '',
+            '                                                            Showing [1] routes'
+        ]);
 
-  GET|HEAD       / ..................................................... index
-
-                                                            Showing [1] routes
-EOF;
         // Due to using PHP_EOL this should fail (conditionally) when run on windows
         $actual = implode(PHP_EOL, [
             '',

--- a/tests/Unit/Drivers/TextDriverTest.php
+++ b/tests/Unit/Drivers/TextDriverTest.php
@@ -29,7 +29,7 @@ EOF));
     }
 
     /** @test */
-    public function it_can_serialize_when_given_windows_line_endings()
+    public function it_can_serialize_when_given_OS_dependant_line_endings()
     {
         $driver = new TextDriver();
 

--- a/tests/Unit/Drivers/TextDriverTest.php
+++ b/tests/Unit/Drivers/TextDriverTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Spatie\Snapshots\Test\Unit\Drivers;
+
+use PHPUnit\Framework\TestCase;
+use Spatie\Snapshots\Drivers\TextDriver;
+use Spatie\Snapshots\Exceptions\CantBeSerialized;
+
+class TextDriverTest extends TestCase
+{
+    /** @test */
+    public function it_can_serialize_laravel_route_list()
+    {
+        $driver = new TextDriver();
+
+        $expected = implode("\n", [
+            '',
+            '  GET|HEAD       / ..................................................... index',
+            '',
+            '                                                            Showing [1] routes'
+        ]);
+
+        $this->assertEquals($expected, $driver->serialize(<<<EOF
+
+  GET|HEAD       / ..................................................... index
+
+                                                            Showing [1] routes
+EOF));
+    }
+
+    /** @test */
+    public function it_can_serialize_when_given_windows_line_endings()
+    {
+        $driver = new TextDriver();
+
+        $expected = <<<EOF
+
+  GET|HEAD       / ..................................................... index
+
+                                                            Showing [1] routes
+EOF;
+        // Due to using PHP_EOL this should fail (conditionally) when run on windows
+        $actual = implode(PHP_EOL, [
+            '',
+            '  GET|HEAD       / ..................................................... index',
+            '',
+            '                                                            Showing [1] routes'
+        ]);
+
+        $this->assertEquals($expected, $driver->serialize($actual));
+    }
+
+}


### PR DESCRIPTION
~Initially this PR will just be adding tests - in theory these tests will add a failing condition to windows runs only. This gives us a TDD based target to verify the patch I have in mind.~

This PR applies a fix similar to #136, however it applies to the Text driver. This PR will fix bugs encountered in CI environments like this: https://github.com/KickflipCli/kickflip-src/runs/7523509151?check_suite_focus=true#step:10:22