### PR TITLE
Apply PCRE_UTF8 for cleaning filename

### DIFF
--- a/src/Filename.php
+++ b/src/Filename.php
@@ -8,7 +8,7 @@ class Filename
     {
         // Remove anything which isn't a word, whitespace, number
         // or any of the following caracters -_~,;[]().
-        $file = preg_replace("([^\w\s\d\-_~,;\[\]\(\).])", '', $raw);
+        $file = preg_replace("([^\w\s\d\-_~,;\[\]\(\).])u", '', $raw);
 
         // Remove any runs of periods
         $file = preg_replace("([\.]{2,})", '', $file);

--- a/tests/Unit/FilenameTest.php
+++ b/tests/Unit/FilenameTest.php
@@ -7,11 +7,20 @@ use Spatie\Snapshots\Filename;
 
 class FilenameTest extends TestCase
 {
-    /** @test */
-    public function it_creates_a_filename_which_is_valid_on_all_systems()
+    /**
+     * @test
+     * @dataProvider fileNameProvider
+     */
+    public function it_creates_a_filename_which_is_valid_on_all_systems($name, $expected)
     {
-        $name = 'ClassTest__testOne with... data set "Empty".php';
+        $this->assertEquals($expected, Filename::cleanFilename($name));
+    }
 
-        $this->assertEquals('ClassTest__testOne with data set Empty.php', Filename::cleanFilename($name));
+    public function fileNameProvider()
+    {
+        return [
+            ['ClassTest__testOne with... data set "Empty".php', 'ClassTest__testOne with data set Empty.php'],
+            ['ClassTest__testOne with... data set "空".php', 'ClassTest__testOne with data set 空.php'],
+        ];
     }
 }


### PR DESCRIPTION
If PCRE_UTF8 is not used in the filename cleaning process, unexpected characters may be erased.
I found this when using Japanese in the data set.