### PR TITLE
serialize empty HTML

### DIFF
--- a/src/Drivers/HtmlDriver.php
+++ b/src/Drivers/HtmlDriver.php
@@ -15,6 +15,10 @@ class HtmlDriver implements Driver
             throw new CantBeSerialized('Only strings can be serialized to html');
         }
 
+        if ('' === $data) {
+            return "\n";
+        }
+
         $domDocument = new DOMDocument('1.0');
         $domDocument->preserveWhiteSpace = false;
         $domDocument->formatOutput = true;

--- a/tests/Unit/Drivers/HtmlDriverTest.php
+++ b/tests/Unit/Drivers/HtmlDriverTest.php
@@ -71,4 +71,12 @@ class HtmlDriverTest extends TestCase
 
         $driver->serialize(['foo' => 'bar']);
     }
+
+    /** @test */
+    public function it_can_serialize_an_empty_string()
+    {
+        $driver = new HtmlDriver();
+
+        $this->assertEquals("\n", $driver->serialize(''));
+    }
 }


### PR DESCRIPTION
Calling `assertMatchesHtmlSnapshot('')` fails in PHP 8.x. In PHP 7.x this works fine.

As far as I can tell, the reason is that calling `DOMDocument::loadHTML('')` now causes a `ValueError` where previously a Warning was emitted, which was suppressed.

I chose a line break as the serialized value for an empty string to be backwards compatible.