### PR TITLE
Generate snapshot file names with dataset

### DIFF
--- a/src/Concerns/SnapshotIdAware.php
+++ b/src/Concerns/SnapshotIdAware.php
@@ -13,7 +13,7 @@ trait SnapshotIdAware
     protected function getSnapshotId(): string
     {
         return (new ReflectionClass($this))->getShortName().'__'.
-            $this->name().'__'.
+            $this->nameWithDataSet().'__'.
             $this->snapshotIncrementor;
     }
 }


### PR DESCRIPTION
Add the data set name to the snapshot file names to generate separate snapshot files when dataProviders are used. 

This should fix #162 and probably #161