### PR TITLE
Change `@after` to `@postCondition`

### DIFF
--- a/src/MatchesSnapshots.php
+++ b/src/MatchesSnapshots.php
@@ -28,7 +28,7 @@ trait MatchesSnapshots
         $this->snapshotIncrementor = 0;
     }
 
-    /** @after */
+    /** @postCondition */
     public function markTestIncompleteIfSnapshotsHaveChanged()
     {
         if (empty($this->snapshotChanges)) {


### PR DESCRIPTION
## Summary
The former will not work with 10.1 anymore, according to phpunit this was an unintended side effect, see https://github.com/sebastianbergmann/phpunit/issues/5337#issuecomment-1513000069

Fixes https://github.com/spatie/phpunit-snapshot-assertions/issues/167

### Notes
The test suite in this framework does not cover the presence of this phpdoc (when I removed it, all tests were still green).

Upfront I tested this in a local installation of phpunit-snapshot-assertions (though it was an older version, still using PHP 7.4 there), but I could already confirm even for that version and PHPUnit <10 in that case, it worked.