### PR TITLE
Allow phpunit 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "ext-json": "*",
         "ext-libxml": "*",
         "composer-runtime-api": "^2.0",
-        "phpunit/phpunit": "^10.0",
+        "phpunit/phpunit": "^10.0|^11.0",
         "symfony/property-access": "^5.2|^6.2|^7.0",
         "symfony/serializer": "^5.2|^6.2|^7.0",
         "symfony/yaml": "^5.2|^6.2|^7.0"

--- a/src/MatchesSnapshots.php
+++ b/src/MatchesSnapshots.php
@@ -49,7 +49,7 @@ trait MatchesSnapshots
         $this->markTestIncomplete($formattedMessages);
     }
 
-    public function assertMatchesSnapshot($actual, Driver $driver = null): void
+    public function assertMatchesSnapshot($actual, ?Driver $driver = null): void
     {
         if (! is_null($driver)) {
             $this->doSnapshotAssertion($actual, $driver);


### PR DESCRIPTION
# Summary
- Expand version constraint to allow phpunit 11, [just released](https://phpunit.de/announcements/phpunit-11.html)
- Check the action with "prefer-stable" and we see it picks phpunit 11
  E.g. https://github.com/spatie/phpunit-snapshot-assertions/actions/runs/7761804048/job/21170990782?pr=185#step:6:22
  > `- Locking phpunit/phpunit (11.0.1)`
  "prefer-lowest" OTOH still picks phpunit 10

### Notes
- The change in `MatchesSnapshots.php` is done by the bot, not by me