### PR TITLE
Improve readability of generated JSON snapshots

### DIFF
--- a/src/Drivers/JsonDriver.php
+++ b/src/Drivers/JsonDriver.php
@@ -18,7 +18,7 @@ class JsonDriver implements Driver
             throw new CantBeSerialized('Resources can not be serialized to json');
         }
 
-        return json_encode($data, JSON_PRETTY_PRINT)."\n";
+        return json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)."\n";
     }
 
     public function extension(): string

--- a/tests/Unit/Drivers/JsonDriverTest.php
+++ b/tests/Unit/Drivers/JsonDriverTest.php
@@ -18,12 +18,12 @@ class JsonDriverTest extends TestCase
 
         $expected = implode("\n", [
             '{',
-            '    "foo": "bar"',
+            '    "foo": "bar/baz 😊"',
             '}',
             '',
         ]);
 
-        $this->assertEquals($expected, $driver->serialize('{"foo":"bar"}'));
+        $this->assertEquals($expected, $driver->serialize('{"foo":"bar\/baz \ud83d\ude0a"}'));
     }
 
     #[Test]
@@ -135,6 +135,7 @@ class JsonDriverTest extends TestCase
     #[TestWith(['1', '1', true])]
     #[TestWith(['1.1', '1.1', true])]
     #[TestWith(['{"empty": []}', '{"empty":{}}', false])]
+    #[TestWith(['{"url": "foo\/bar😊"}', '{"url":"foo/bar\ud83d\ude0a"}', true])]
     public function it_can_match_json_strings(string $expected, string $actual, bool $assertion)
     {
         $driver = new JsonDriver;


### PR DESCRIPTION
We have lot of snapshots containing links. I am sure it will be much easier to read them if they are unescaped. Most languages do not do these escapings by default, PHP does it because of some security-wise XSS edge cases that are not relevant here.