### PR TITLE
Allow phpunit 12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "ext-json": "*",
         "ext-libxml": "*",
         "composer-runtime-api": "^2.0",
-        "phpunit/phpunit": "^10.0|^11.0",
+        "phpunit/phpunit": "^10.0|^11.0|^12.0",
         "symfony/property-access": "^5.2|^6.2|^7.0",
         "symfony/serializer": "^5.2|^6.2|^7.0",
         "symfony/yaml": "^5.2|^6.2|^7.0"


### PR DESCRIPTION
Expand version constraint to allow phpunit 12, [just released](https://phpunit.de/announcements/phpunit-12.html)