### PR TITLE
Allow `assertMatchesJsonSnapshot` to accept any JSON-serializable value

### DIFF
--- a/src/MatchesSnapshots.php
+++ b/src/MatchesSnapshots.php
@@ -89,7 +89,7 @@ trait MatchesSnapshots
         $this->assertMatchesSnapshot($actual, new HtmlDriver);
     }
 
-    public function assertMatchesJsonSnapshot(array|string|null|int|float|bool $actual): void
+    public function assertMatchesJsonSnapshot($actual): void
     {
         $this->assertMatchesSnapshot($actual, new JsonDriver);
     }


### PR DESCRIPTION
This PR removes the strict type annotation from the `$actual` parameter in `assertMatchesJsonSnapshot()` to allow any JSON-serializable value, including `JsonSerializable` objects.

The underlying `JsonDriver` already accepts mixed input, so this change relaxes the input constraint to better reflect its capabilities. It also improves consistency with other `assertMatches*Snapshot` methods, which do not restrict input types.