### PR TITLE
Update parameter type hints in ObjectDriver constructor docblock

### DIFF
--- a/src/Drivers/ObjectDriver.php
+++ b/src/Drivers/ObjectDriver.php
@@ -20,9 +20,9 @@ class ObjectDriver implements Driver
 
     /**
      * @param array{
-     *     yaml_inline: int,
-     *     yaml_indent: int,
-     *     yaml_flags: int
+     *     yaml_inline?: int,
+     *     yaml_indent?: int,
+     *     yaml_flags?: int
      * } $yamlConfig
      */
     public function __construct(


### PR DESCRIPTION
issue #218

Static analysis like PHPStan complains about missing keys for optional parameter of the ObjectDriver constructor.
