### PR TITLE
Added `setSnapshotId` method to easily override the snapshot identifier

### DIFF
--- a/src/Concerns/SnapshotIdAware.php
+++ b/src/Concerns/SnapshotIdAware.php
@@ -6,14 +6,25 @@ use ReflectionClass;
 
 trait SnapshotIdAware
 {
+    private ?string $snapshotId = null;
+
     /*
      * Determines the snapshot's id. By default, the test case's class and
      * method names are used.
      */
     protected function getSnapshotId(): string
     {
+        if ($this->snapshotId !== null) {
+            return $this->snapshotId;
+        }
+
         return (new ReflectionClass($this))->getShortName().'__'.
             $this->nameWithDataSet().'__'.
             $this->snapshotIncrementor;
+    }
+
+    protected function setSnapshotId(string $snapshotId): void
+    {
+        $this->snapshotId = $snapshotId;
     }
 }


### PR DESCRIPTION
In my project I have the following:
```
    #[Test]
    #[TestWith(['name' => 'dummy_name'])]
    public function testCompile(string $name): void
    {
        $result = [... retrieve file based on $name ...];

        $this->setSnapshotId($name);
        $this->assertMatchesSnapshot($result);
    }
```

This way it is possible to store the snapshot file using the same filename (without extension), to easily find the snapshot file based on the input file. At this moment I need to add extra code for this to make it work.

Example:
- __fixtures__/dummy_name.txt
- __snapshots__/dummy_name.yml

Let me know if unit tests are needed for this.