### PR TITLE
remove ReflectionProperty::setAccessible

### DIFF
--- a/src/MatchesSnapshots.php
+++ b/src/MatchesSnapshots.php
@@ -297,7 +297,6 @@ trait MatchesSnapshots
         $exceptionReflection = new ReflectionObject($exception);
 
         $messageReflection = $exceptionReflection->getProperty('message');
-        $messageReflection->setAccessible(true);
         $messageReflection->setValue($exception, $newMessage);
 
         throw $exception;


### PR DESCRIPTION
Remove call to [ReflectionProperty::setAccessible](https://www.php.net/manual/en/reflectionproperty.setaccessible.php) as it has been a no-op since PHP 8.1 and deprecated in 8.5.