### PR TITLE
feat: allow PHPUnit 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "ext-json": "*",
         "ext-libxml": "*",
         "composer-runtime-api": "^2.0",
-        "phpunit/phpunit": "^10.0|^11.0|^12.0",
+        "phpunit/phpunit": "^9.6|^10.0|^11.0|^12.0",
         "symfony/property-access": "^5.2|^6.2|^7.0|^8.0",
         "symfony/serializer": "^5.2|^6.2|^7.0|^8.0",
         "symfony/yaml": "^5.2|^6.2|^7.0|^8.0"


### PR DESCRIPTION
there is a need for a run with PHPUnit 9 and symfony 8

Example:
https://github.com/symfony/ux/actions/runs/19576989865/job/56064870069

```
   - Root composer.json requires spatie/phpunit-snapshot-assertions ^4.2.17|^5.2.3 -> satisfiable by spatie/phpunit-snapshot-assertions[4.2.17, 5.2.3].
    - spatie/phpunit-snapshot-assertions 4.2.17 requires symfony/property-access ^4.0|^5.0|^6.0|^7.0 -> found symfony/property-access[v4.0.0-RC1, ..., v4.4.44, v5.0.0-RC1, ..., v5.4.45, v6.0.0-RC1, ..., v6.4.25, v7.0.0-RC1, ..., v7.4.0-RC1] but these were not loaded, likely because it conflicts with another require.
    - spatie/phpunit-snapshot-assertions 5.2.3 requires phpunit/phpunit ^10.0|^11.0|^12.0 -> found phpunit/phpunit[10.0.0, ..., 10.5.58, 11.0.0, ..., 11.5.44, 12.0.0, ..., 12.4.4] but it conflicts with your root composer.json require (^9.6.22).
```